### PR TITLE
Prevent oversized PyMOL tool results from overflowing Claude SDK buffer

### DIFF
--- a/modules/pymol/ai/runtime.py
+++ b/modules/pymol/ai/runtime.py
@@ -806,6 +806,69 @@ class AiRuntime:
         }
 
     @staticmethod
+    def _truncate_preview_text(text: str, max_chars: int) -> str:
+        raw = str(text or "")
+        limit = max(64, int(max_chars))
+        if len(raw) <= limit:
+            return raw
+        head = max(32, int(limit * 0.7))
+        tail = max(16, limit - head - 32)
+        omitted = max(0, len(raw) - head - tail)
+        return "%s\n... [truncated %d chars] ...\n%s" % (raw[:head], omitted, raw[-tail:])
+
+    def _sdk_safe_run_command_payload(self, payload: Dict[str, object]) -> Dict[str, object]:
+        """
+        Guard against oversized MCP tool-result JSON messages. Claude SDK's
+        message reader can fail hard when a single JSON payload exceeds the
+        configured buffer (default 10 MiB).
+        """
+        limit = int(self.sdk_max_buffer_size or (10 * 1024 * 1024))
+        target = max(16_384, min(512_000, max(16_384, limit // 4)))
+
+        serialized = self._tool_result_content(payload)
+        if len(serialized) <= target:
+            return payload
+
+        trimmed = dict(payload)
+
+        command_text = str(trimmed.get("command") or "")
+        if len(command_text) > 8_192:
+            trimmed["command"] = self._truncate_preview_text(command_text, 8_192)
+            trimmed["command_truncated"] = True
+
+        error_text = str(trimmed.get("error") or "")
+        if error_text and len(error_text) > 8_192:
+            trimmed["error"] = self._truncate_preview_text(error_text, 8_192)
+
+        feedback_lines = [str(x) for x in (trimmed.get("feedback_lines") or [])]
+        if feedback_lines:
+            joined = "\n".join(feedback_lines)
+            preview_budget = max(4_096, min(128_000, target // 2))
+            trimmed["feedback_lines"] = [
+                "[tool output truncated to avoid SDK message overflow]",
+                "original_feedback_lines=%d original_feedback_chars=%d" % (
+                    len(feedback_lines),
+                    len(joined),
+                ),
+                self._truncate_preview_text(joined, preview_budget),
+            ]
+        else:
+            trimmed["feedback_lines"] = ["[tool output omitted: payload exceeded SDK buffer target]"]
+
+        trimmed["truncated"] = True
+        trimmed["truncation_reason"] = "sdk_buffer_guard"
+
+        # Last-resort clamp if command/error fields are still too large.
+        serialized = self._tool_result_content(trimmed)
+        if len(serialized) > target:
+            trimmed["feedback_lines"] = ["[tool output omitted: exceeded SDK transport limit]"]
+            trimmed["command"] = self._truncate_preview_text(str(trimmed.get("command") or ""), 2_048)
+            if trimmed.get("error"):
+                trimmed["error"] = self._truncate_preview_text(str(trimmed.get("error") or ""), 2_048)
+
+        return trimmed
+
+    @staticmethod
     def _normalized_command_key(command: str) -> str:
         return re.sub(r"\s+", " ", str(command or "").strip().lower())
 
@@ -923,6 +986,14 @@ class AiRuntime:
                     "error": exec_result.error or None,
                     "feedback_lines": exec_result.feedback_lines,
                 }
+                payload = self._sdk_safe_run_command_payload(payload)
+                if payload.get("truncated"):
+                    self._log_ai(
+                        "tool run payload truncated for sdk transport",
+                        level="WARNING",
+                        tool_call_id=tool_call_id,
+                        command=command,
+                    )
                 metadata = {
                     "tool_call_id": tool_call_id,
                     "tool_name": "run_pymol_command",


### PR DESCRIPTION
## Summary

Prevent oversized `run_pymol_command` tool results from crashing the Claude SDK JSON message reader when a PyMOL command prints a very large payload (for example `print(cmd.get_session())`).

## Problem

While using PyMolAI interactively, a tool invocation that printed `cmd.get_session()` produced a huge JSON tool result. The Claude SDK message reader then failed with:

- `Fatal error in message reader: Failed to decode JSON: JSON message exceeded maximum buffer size of 10485760 bytes...`

This leaves the AI turn unusable and requires cancelling/restarting the session.

## Root Cause

`run_pymol_command` payloads (especially `feedback_lines`) are returned to the Claude SDK MCP tool server without a transport-size guard. If a command emits a large textual result, the serialized JSON tool result can exceed the SDK buffer limit.

## Fix

- Add `_sdk_safe_run_command_payload(...)` to shrink oversized `run_pymol_command` payloads before sending them to the SDK.
- Preserve key metadata (`ok`, `command`, `error`) while truncating large `feedback_lines` to a preview.
- Mark truncated payloads with `truncated=True` and `truncation_reason="sdk_buffer_guard"`.
- Emit a warning log when truncation is applied.

## Why this approach

This is a defensive transport-layer safeguard. It avoids a hard failure in the agent loop while preserving enough context for the model and UI to continue.

## Repro (before fix)

1. Ask the AI to run a Python tool command that prints a large object, e.g. `cmd.get_session()`.
2. The tool result JSON exceeds the Claude SDK reader buffer.
3. The SDK reader crashes with a max-buffer decode error.

## Validation

- `python -m py_compile modules/pymol/ai/runtime.py`
- Manual local repro path (large tool output) no longer overflows the SDK transport payload after truncation guard.

